### PR TITLE
Add in-memory caching for original images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Deprecate `ImagePipeline.Configuration.callbackQueue` – this feature will be removed in Nuke 13
 - `ImagePrefetcher.didComplete` closure is now annotated with `@MainActor @Sendable`
 - Drop Xcode 14 support
+- Add `isStoringOriginalImagesInMemoryCache` option to store original images in memory for processed requests
 
 ## Nuke 12.7.3
 

--- a/Documentation/Nuke.docc/Extensions/ImagePipelineConfiguration-Extension.md
+++ b/Documentation/Nuke.docc/Extensions/ImagePipelineConfiguration-Extension.md
@@ -27,6 +27,7 @@ To learn more about caching, see <doc:caching>.
 - ``dataCachePolicy``
 - ``ImagePipeline/DataCachePolicy``
 - ``isStoringPreviewsInMemoryCache``
+- ``isStoringOriginalImagesInMemoryCache``
 
 ### Other Options
 

--- a/Documentation/Nuke.docc/Performance/Caching/accessing-caches.md
+++ b/Documentation/Nuke.docc/Performance/Caching/accessing-caches.md
@@ -50,6 +50,7 @@ pipeline.cache[ImageRequest(url: url)] = nil
 ```
 
 > ``ImageContainer`` contains some metadata about the image, and in the case of animated images or other images that require non-trivial rendering, also contains `data`. It also allows you to distinguish between progressive previews in case ``ImagePipeline/Configuration-swift.struct/isStoringPreviewsInMemoryCache`` option is enabled.
+> You can also store original images for processed requests in memory using ``ImagePipeline/Configuration-swift.struct/isStoringOriginalImagesInMemoryCache``.
 
 All ``ImagePipeline/Cache-swift.struct`` respect request cache control options.
 

--- a/Sources/Nuke/Pipeline/ImagePipeline+Configuration.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline+Configuration.swift
@@ -108,6 +108,10 @@ extension ImagePipeline {
         /// previews have ``ImageContainer/isPreview`` flag set to `true`.
         public var isStoringPreviewsInMemoryCache = true
 
+        /// `false` by default. If `true`, the pipeline will store original images
+        /// in the memory cache when fetching processed images.
+        public var isStoringOriginalImagesInMemoryCache = false
+
         /// If the data task is terminated (either because of a failure or a
         /// cancellation) and the image was partially loaded, the next load will
         /// resume where it left off. Supports both validators (`ETag`,

--- a/Sources/Nuke/Tasks/TaskFetchOriginalImage.swift
+++ b/Sources/Nuke/Tasks/TaskFetchOriginalImage.swift
@@ -48,6 +48,9 @@ final class TaskFetchOriginalImage: AsyncPipelineTask<ImageResponse>, @unchecked
 
         switch result {
         case .success(let response):
+            if context.isCompleted {
+                storeOriginalImageInMemoryCacheIfNeeded(response.container)
+            }
             send(value: response, isCompleted: context.isCompleted)
         case .failure(let error):
             if context.isCompleted {
@@ -65,5 +68,33 @@ final class TaskFetchOriginalImage: AsyncPipelineTask<ImageResponse>, @unchecked
         let decoder = pipeline.delegate.imageDecoder(for: context, pipeline: pipeline)
         self.decoder = decoder
         return decoder
+    }
+
+    private func storeOriginalImageInMemoryCacheIfNeeded(_ container: ImageContainer) {
+        let request = makeSanitizedRequest()
+        guard shouldStoreOriginalInMemoryCache(),
+              let imageCache = pipeline.delegate.imageCache(for: request, pipeline: pipeline) else {
+            return
+        }
+        let key = pipeline.cache.makeImageCacheKey(for: request)
+        imageCache[key] = container
+    }
+
+    private func makeSanitizedRequest() -> ImageRequest {
+        var request = request
+        request.processors = []
+        request.userInfo[.thumbnailKey] = nil
+        return request
+    }
+
+    private func shouldStoreOriginalInMemoryCache() -> Bool {
+        guard pipeline.configuration.isStoringOriginalImagesInMemoryCache else {
+            return false
+        }
+        let tasks = imageTasks
+        guard tasks.contains(where: { !$0.request.options.contains(.disableMemoryCacheWrites) }) else {
+            return false
+        }
+        return !request.processors.isEmpty
     }
 }

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineCacheTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineCacheTests.swift
@@ -456,6 +456,40 @@ class ImagePipelineCacheTests: XCTestCase {
         XCTAssertNil(diskCache.cachedData(for: cache.makeDataCacheKey(for: request)))
     }
 
+    // MARK: Store Original Images
+
+    func testStoreOriginalImageInMemoryWhenEnabled() {
+        // GIVEN
+        pipeline = pipeline.reconfigured {
+            $0.isStoringOriginalImagesInMemoryCache = true
+        }
+        let processed = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "p1")])
+
+        // WHEN
+        expect(pipeline).toLoadImage(with: processed)
+        wait()
+
+        // THEN original image is cached in memory
+        let originalKey = pipeline.cache.makeImageCacheKey(for: ImageRequest(url: Test.url))
+        XCTAssertNotNil(memoryCache[originalKey])
+    }
+
+    func testStoreOriginalImageInMemoryWhenDisabled() {
+        // GIVEN
+        pipeline = pipeline.reconfigured {
+            $0.isStoringOriginalImagesInMemoryCache = false
+        }
+        let processed = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "p1")])
+
+        // WHEN
+        expect(pipeline).toLoadImage(with: processed)
+        wait()
+
+        // THEN original image is not cached in memory
+        let originalKey = pipeline.cache.makeImageCacheKey(for: ImageRequest(url: Test.url))
+        XCTAssertNil(memoryCache[originalKey])
+    }
+
     // MARK: - Image Orientation
 
 #if canImport(UIKit)


### PR DESCRIPTION
## Summary
- add `isStoringOriginalImagesInMemoryCache` option
- use this option when decoding original images
- document the option
- update changelog
- test that original images are cached in memory when enabled

## Testing
- `swift package describe`
- `swift test --enable-code-coverage` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_684552e0a860832599a71223e95a8008